### PR TITLE
Increase timeouts

### DIFF
--- a/song_signup/static/js/add-song.js
+++ b/song_signup/static/js/add-song.js
@@ -86,4 +86,4 @@ function checkDisableSignup() {
         });
 }
 
-setInterval(checkDisableSignup, 500);
+setInterval(checkDisableSignup, 5000);

--- a/song_signup/static/js/base.js
+++ b/song_signup/static/js/base.js
@@ -23,7 +23,7 @@ answers.forEach(answer => {
 const csrftoken = getCookie('csrftoken');
 
 if (isLoggedIn) {
-    setInterval(getQuestion, 500);
+    setInterval(getQuestion, 2000);
 }
 
 async function getQuestion() {

--- a/song_signup/static/js/home.js
+++ b/song_signup/static/js/home.js
@@ -11,7 +11,7 @@ const dashboardElem = document.getElementById("home-dashboard");
 const noSongElem = document.getElementById("no-song");
 const spotlightElem = document.getElementById("now-singing-wrapper");
 
-setInterval(populateSpotlight, 1000);
+setInterval(populateSpotlight, 5000);
 window.addEventListener("DOMContentLoaded", loadWait(populateSpotlight));
 
 
@@ -95,7 +95,7 @@ function populateDashboard() {
 }
 
 if (isSinger) {
-    setInterval(populateDashboard, 1000);
+    setInterval(populateDashboard, 5000);
     window.addEventListener("DOMContentLoaded", loadWait(populateDashboard));
 
     // Open up dashboard tips

--- a/song_signup/static/js/live-lyrics.js
+++ b/song_signup/static/js/live-lyrics.js
@@ -249,5 +249,5 @@ async function populateLyrics() {
             currentSong = lyricsData.song_name;
             window.scrollTo(0, 0);
         }
-    } 
+    }
 }

--- a/templates/admin/song_request_changelist.html
+++ b/templates/admin/song_request_changelist.html
@@ -179,7 +179,7 @@
                     window.location.href = "/end_spotlight";
                 });
             }
-            setInterval(readShaniPing, 100);
+            setInterval(readShaniPing, 1000);
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Opening the site on mobile is a serious battery drain. I think a large part of the problem is the very low timeouts for network refreshes.

Also the cell service in the bar sucks and I think the large amount of requests actually causes less responsiveness.

This PR pushes up the intervals enough to hopefully make a difference without significantly effecting latency.